### PR TITLE
Fixing incorrect encoding of an HTML entity within an HTML attribute.

### DIFF
--- a/lib/src/font-roboto/roboto.html
+++ b/lib/src/font-roboto/roboto.html
@@ -6,4 +6,4 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
The source of an annoying pub build warning:

line 9, column 1 of package:paper_elements/src/font-roboto/roboto.html: Named entity expected. Got none.
<link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&lang=
